### PR TITLE
Tweak the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Set the `--context` argument to the kubectl context to your staging cluster and 
 
 ```sh
 flux bootstrap github \
-    --context=staging \
+    --context=your-staging-context \
     --owner=${GITHUB_USER} \
     --repository=${GITHUB_REPO} \
     --branch=main \

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Verify that your staging cluster satisfies the prerequisites with:
 flux check --pre
 ```
 
-Set the kubectl context to your staging cluster and bootstrap Flux:
+Set the `--context` argument to the kubectl context to your staging cluster and bootstrap Flux:
 
 ```sh
 flux bootstrap github \


### PR DESCRIPTION
## What? 
Change the wording to be more explicit
Change the example command context to avoid collisions

## Why?
I got stuck with the instructions as I thought that as long as my current context was set correctly the I could copy and paste the command.  Unfortunately, we have a staging cluster in our environment which clashed with the instructions resulting in an obscure error:

`✗ sync path configuration ("./clusters/staging") would overwrite path ("./flux/staging") of existing Kustomization`

I changed the example command to make it less likely to clash with a users existing config

## Tested?
I checked the rendered file in GH