### PR TITLE
Following best-practice advice for non-root user

### DIFF
--- a/.github/actions/tools/Dockerfile
+++ b/.github/actions/tools/Dockerfile
@@ -2,5 +2,5 @@ FROM stefanprodan/alpine-base:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
+USER 1001
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This just sets a non-root user for the container that is built by our GitHub Action for validating YAMLs in CI.

Following the change that was made in:

* https://github.com/fluxcd/flux2-kustomize-helm-example/pull/35

This is the Dockerfile change I mentioned that was also needed to go with:

* https://github.com/fluxcd/flux2-kustomize-helm-example/pull/38

The goal of these two changes is just to make sure the examples are close together as possible, and any differences wrt. validation scripts are meant to be normalized out to make sure both tutorials followed along with whichever version is better whenever someone came along and made an enhancement to either one.