### PR TITLE
Fix Kyverno policy for Flux Kustomizations

### DIFF
--- a/infrastructure/kyverno-policies/flux-multi-tenancy.yaml
+++ b/infrastructure/kyverno-policies/flux-multi-tenancy.yaml
@@ -28,7 +28,7 @@ spec:
       match:
         resources:
           kinds:
-            - HelmRelease
+            - Kustomization
       preconditions:
         any:
           - key: "{{request.object.spec.sourceRef.namespace}}"


### PR DESCRIPTION
We (@priyanka-ravi @rparmer02) think the match condition on clusterPolicy - kustomizationSourceRefNamespace should be on Kustomization kind, otherwise the last 2 policies are redundant