### PR TITLE
Update leftovers to kustomize.toolkit.fluxcd.io/v1beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Create the staging overlay and set the path to the staging dir inside the tenant
 
 ```sh
 cat << EOF | tee ./tenants/staging/dev-team-patch.yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: dev-team

--- a/tenants/base/dev-team/sync.yaml
+++ b/tenants/base/dev-team/sync.yaml
@@ -9,7 +9,7 @@ spec:
   ref:
     branch: dev-team
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: dev-team

--- a/tenants/production/dev-team-patch.yaml
+++ b/tenants/production/dev-team-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: dev-team

--- a/tenants/staging/dev-team-patch.yaml
+++ b/tenants/staging/dev-team-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: dev-team


### PR DESCRIPTION
While working through the multi-tenancy getting started guide, I noticed that the flux CLI now generates resources with `kustomize.toolkit.fluxcd.io/v1beta2` - probably because I am now on a recent version of flux CLI. The kustomizations will fail if the version is not aligned. This PR fixes this.