### PR TITLE
Replace kustomize remote base with Flux GitRepository

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,12 +46,16 @@ jobs:
       - name: Verify cluster reconciliation
         run: |
           kubectl -n flux-system wait kustomization/kyverno --for=condition=ready --timeout=1m
+          kubectl -n flux-system wait kustomization/kyverno-controller --for=condition=ready --timeout=1m
           kubectl -n flux-system wait kustomization/kyverno-policies --for=condition=ready --timeout=1m
           kubectl -n flux-system wait kustomization/tenants --for=condition=ready --timeout=3m
       - name: Verify tenant reconciliation
         run: |
           kubectl -n apps wait kustomization/dev-team --for=condition=ready --timeout=1m
           kubectl -n apps wait helmrelease/podinfo --for=condition=ready --timeout=1m
+      - name: List reconciliations
+        run: |
+          flux get all --all-namespaces
       - name: Debug failure
         if: failure()
         run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -25,9 +25,9 @@ jobs:
           head -n1)
           echo ::set-output name=NUMBER::${VERSION}
       - name: Patch version
-        run: |
-          export URL="https://raw.githubusercontent.com/kyverno/kyverno/${{ steps.version.outputs.NUMBER }}/config/release/install.yaml"
-          yq e '.resources[0]=strenv(URL)' -i ./infrastructure/kyverno/kustomization.yaml
+        env:
+          KYVERNO_VERSION: ${{ steps.version.outputs.NUMBER }}
+        run: yq e '.spec.ref.tag=strenv(KYVERNO_VERSION)' -i ./infrastructure/kyverno/source.yaml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kyverno
   namespace: flux-system
 spec:
-  interval: 720m
+  interval: 720m0s
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -12,7 +12,7 @@ spec:
   path: ./infrastructure/kyverno
   prune: true
   wait: true
-  timeout: 5m
+  timeout: 10m
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -22,7 +22,7 @@ metadata:
 spec:
   dependsOn:
     - name: kyverno
-  interval: 15m
+  interval: 15m0s
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/infrastructure/kyverno/kustomization.yaml
+++ b/infrastructure/kyverno/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/kyverno/kyverno/v1.6.0-rc4/config/release/install.yaml
+  - source.yaml
+  - sync.yaml

--- a/infrastructure/kyverno/source.yaml
+++ b/infrastructure/kyverno/source.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: kyverno-controller
+  namespace: flux-system
+spec:
+  interval: 120m0s
+  url: https://github.com/kyverno/kyverno
+  ignore: |
+    /*
+    !/config/
+  ref:
+    tag: "v1.6.0-rc3"

--- a/infrastructure/kyverno/sync.yaml
+++ b/infrastructure/kyverno/sync.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kyverno-controller
+  namespace: flux-system
+spec:
+  interval: 720m0s
+  sourceRef:
+    kind: GitRepository
+    name: kyverno-controller
+  serviceAccountName: kustomize-controller
+  path: ./config/release
+  prune: true
+  wait: true
+  timeout: 5m


### PR DESCRIPTION
Using a Kustomize remote base proves to be unreliable, switching to Flux native sync. 

Given the amounts of cloning timeouts and random Git errors on my test clusters, I think we should encourage Flux users to migrate from Kustomize remote bases (shell-out to git CLI inside kustomize-controller) to Flux GitRepositories as source-controller caches the repos and is way more resilient than kustomize shelling out Git.