### PR TITLE
Set service account name for staging tenants

### DIFF
--- a/clusters/staging/tenants.yaml
+++ b/clusters/staging/tenants.yaml
@@ -7,6 +7,7 @@ spec:
   dependsOn:
     - name: kyverno-policies
   interval: 5m
+  serviceAccountName: kustomize-controller
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Fix bug introduced in #54