### PR TITLE
Install Kyverno using signed OCI artifacts

### DIFF
--- a/infrastructure/kyverno/source.yaml
+++ b/infrastructure/kyverno/source.yaml
@@ -1,13 +1,13 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: GitRepository
+kind: OCIRepository
 metadata:
   name: kyverno-controller
   namespace: flux-system
 spec:
   interval: 120m0s
-  url: https://github.com/kyverno/kyverno
-  ignore: |
-    /*
-    !/config/
+  provider: generic
+  url: oci://ghcr.io/kyverno/manifests/kyverno
   ref:
-    tag: "v1.7.3"
+    tag: "v1.8.0"
+  verify:
+    provider: cosign

--- a/infrastructure/kyverno/sync.yaml
+++ b/infrastructure/kyverno/sync.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   interval: 720m0s
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: kyverno-controller
   serviceAccountName: kustomize-controller
-  path: ./config/release
+  path: ./
   prune: true
   wait: true
   timeout: 5m


### PR DESCRIPTION
Switch the Kyverno source from `GitRepository` to `OCIRepository` and enabled Cosign keyless verification of Kyverno OCI artifacts.

From a security perspective, this change is a major improvement towards a safer deploy pipeline for critical cluster addons. Instead of blindly trusting the Kyverno Git repository host, Flux now verifies the authenticity of Kyverno manifests fetched from `oci://ghcr.io/kyverno/manifests/kyverno` using the public transparency log hosted at [rekor.sigstore.dev](https://rekor.sigstore.dev).

Ref: https://github.com/kyverno/kyverno/pull/4895 https://github.com/kyverno/kyverno/issues/4869