### PR TITLE
Set Kyverno policy failure to audit

### DIFF
--- a/infrastructure/kyverno-policies/verify-flux-images.yaml
+++ b/infrastructure/kyverno-policies/verify-flux-images.yaml
@@ -3,7 +3,7 @@ kind: ClusterPolicy
 metadata:
   name: verify-flux-images
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Audit
   background: false
   webhookTimeoutSeconds: 30
   failurePolicy: Fail


### PR DESCRIPTION
Prevent Kyverno from blocking Flux reconciliation due to missing digest bug.

Ref: #107 