### PR TITLE
Add namespace reference to kustomize files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ flux create kustomization dev-team \
 Create the base `kustomization.yaml` file:
 
 ```sh
-cd ./tenants/base/dev-team/ && kustomize create --autodetect
+cd ./tenants/base/dev-team/ && kustomize create --autodetect --namespace apps 
 ```
 
 Create the staging overlay and set the path to the staging dir inside the tenant repository:
@@ -199,6 +199,7 @@ EOF
 cat << EOF | tee ./tenants/staging/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: apps
 resources:
   - ../base/dev-team
 patches:

--- a/tenants/base/dev-team/kustomization.yaml
+++ b/tenants/base/dev-team/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: apps
 resources:
   - rbac.yaml
   - sync.yaml

--- a/tenants/production/kustomization.yaml
+++ b/tenants/production/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: apps
 resources:
   - ../base/dev-team
 patches:

--- a/tenants/staging/kustomization.yaml
+++ b/tenants/staging/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: apps
 resources:
   - ../base/dev-team
 patches:


### PR DESCRIPTION
While following the steps from the ReadME I ran into this error when setting up the kustomize files: "failed to find unique target for patch" 

Reason for that seems to be a missing namespace reference, which is required since kustomize v3.0.x (https://github.com/kubernetes-sigs/kustomize/issues/1351 and https://github.com/kubernetes-sigs/kustomize/issues/1332) 

I added the namespace flag/reference to the docs/files to avoid that other people run into the same issue. 