### PR TITLE
Fix shell command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ flux -n apps create secret git dev-team-auth \
 Print the SSH public key and add it as a read-only deploy key to the dev-team repository:
 
 ```sh
-yq eval 'data."identity.pub"' git-auth.yaml | base64 --decode
+yq eval '.stringData."identity.pub"' ./tenants/base/dev-team/auth.yaml
 ```
 
 ### Git over HTTP/S


### PR DESCRIPTION
If applied, this commit will correct the yq command to extract the public key from the secret.

Changes done:
- fix the $ yq .stringData key path
- remove the "| base64 --decode" as the key is not encoded when generated by the $ flux create secret git command
- use the proper path to the file according to the previous command in the README step-by-step explanation

The proper use of the $ yq command can also be verified directly in the official help section $ flux create secret git --help
Launch it and search for "yq" to jump directly to the --help example.